### PR TITLE
allow for specifying DLL path when using the SDK-type Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.1.0
+- Added additional parameter option when using Unity Configuration to target the correct directory with the Net Password SDK DLL
+- Added additional parameter option when using Unity Configuration to specify if the Net Framework or Net Standard Password SDK should be used
+- Improve logging and error handling to report errors correctly
+
 2.0.1
 - Bug fix for DLL compatibility issue preventing CyberArk from loading correctly on the Keyfactor Platform
 - Include `manifest.json` and alternate `SDK-manifest.json` files and instructions on their use

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ This file then needs to be edited to enter in the "initialization" parameters fo
 
 #### Usage with the Keyfactor Universal Orchestrator
 To use the PAM Provider to resolve a field, for example a Server Password, instead of entering in the actual value for the Server Password, enter a `json` object with the parameters specifying the field.
-The parameters needed are the "instance" parameters above:
+The parameters needed are the "instance" parameters above (with appropriate characters escaped for correct JSON formatting):
 
 ~~~ json
-{"Safe":"MySafe","Folder":"Root\Secrets","Object":"MySecret"}
+{"Safe":"MySafe","Folder":"Root\\Secrets","Object":"MySecret"}
 ~~~
 
 If a field supports PAM but should not use PAM, simply enter in the actual value to be used instead of the `json` format object above.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A <code>manifest.json</code> file is included in the release. This file needs to
 ~~~ json
 "Keyfactor:PAMProviders:CyberArk-CentralCredentialProvider:InitializationInfo": {
     "AppId": "myappid",
-    "Host": "https://my.cyberark.instance:99999",
+    "Host": "my.cyberark.instance:99999",
     "Site": "WithOutCert"
   }
 ~~~
@@ -150,7 +150,13 @@ The Keyfactor service and IIS Server should be restarted after making these chan
 For registering the CyberArk for use with the SDK-based Credential Provider, use the following `<register>` instead.
 
 ```xml
-<register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider" />
+<register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider">
+  <constructor>
+    <param name="extensionPath">
+      <value value="C:\Program Files\Keyfactor\Keyfactor Platform\WebAgentServices\bin"/>
+    </param>
+  </constructor>
+</register>
 ```
 
 ##### Usage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Keyfactor supports the retrieval of credentials from 3rd party Privileged Access
 
 ## Support for CyberArk PAM Provider
 
-CyberArk PAM Provider is supported by Keyfactor for Keyfactor customers. If you have a support issue, please open a support ticket with your Keyfactor representative.
+CyberArk PAM Provider is supported by Keyfactor for Keyfactor customers. If you have a support issue, please open a support ticket via the Keyfactor Support Portal at https://support.keyfactor.com
 
 ###### To report a problem or suggest a new feature, use the **[Issues](../../issues)** tab. If you want to contribute actual bug fixes or proposed enhancements, use the **[Pull requests](../../pulls)** tab.
 
@@ -149,6 +149,7 @@ The Keyfactor service and IIS Server should be restarted after making these chan
 
 
 For registering the CyberArk for use with the SDK-based Credential Provider, use the following `<register>` instead.
+Make sure to enter in the correct full path to the directory for `extensionPath` that has the SDK DLL for the PAM Provider.
 
 ```xml
 <register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider">

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Certificate Authentication cannot be required. This may necessitate creating a S
 
 #### For SDK-based local Credential Provider
 To use a local Credential Provider instead, the Credential Provider will need to be installed on the machine that is using the PAM Provider. After installing the Credential Provider, copy the `NetStandardPasswordSDK.dll` assembly from the install location into the PAM Provider install location. This dll __needs__ to be adjacent to `cyberark-credentialprovider-pam.dll` to be properly loaded.
+__Important__: When running the SDK Credential Provider on Keyfactor Command, the `NetPasswordSDK.dll` needs to be copied instead of `NetStandardPasswordSDK.dll`. This library is compatible with .NET Framework which is necessary to work in Keyfactor Command.
 
 After registering the Credential Provider during install, make sure the Provider for the machine has been granted permission to access the Safe, as well as the Application ID that will be used.
 

--- a/cyberark-credentialprovider-pam/CentralCredentialProviderPAM.cs
+++ b/cyberark-credentialprovider-pam/CentralCredentialProviderPAM.cs
@@ -20,19 +20,19 @@ using System.Net.Http;
 
 namespace Keyfactor.Extensions.Pam.CyberArk
 {
-    public class CentralCredentialProviderPAM : IPAMProvider
+    public class CentralCredentialProviderPAM : CyberArkProvider, IPAMProvider
     {
         public string Name => "CyberArk-CentralCredentialProvider";
 
         public string GetPassword(Dictionary<string, string> instanceParameters, Dictionary<string, string> initializationInfo)
         {
-            string appId = initializationInfo["AppId"];
-            string host = initializationInfo["Host"];
-            string site = initializationInfo["Site"];
+            string appId = GetRequiredValue(initializationInfo, "AppId");
+            string host = GetRequiredValue(initializationInfo, "Host");
+            string site = GetRequiredValue(initializationInfo, "Site");
 
-            string safe = instanceParameters["Safe"];
-            string folder = instanceParameters["Folder"];
-            string obj = instanceParameters["Object"];
+            string safe = GetRequiredValue(instanceParameters, "Safe");
+            string folder = GetRequiredValue(instanceParameters, "Folder");
+            string obj = GetRequiredValue(instanceParameters, "Object");
 
             var http = new HttpClient();
             http.BaseAddress = new Uri($"https://{host}/");

--- a/cyberark-credentialprovider-pam/Constants.cs
+++ b/cyberark-credentialprovider-pam/Constants.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Keyfactor.Extensions.Pam.CyberArk
+{
+    public static class Constants
+    {
+        public interface SDK
+        {
+            string DLL { get; }
+            string PasswordSDKType { get; }
+            string PasswordRequestType { get; }
+            string PasswordSDKExceptionType { get; }
+            string PasswordResponseType { get; }
+        }
+
+        public class NetStandard : SDK
+        {
+            public string DLL => "NetStandardPasswordSDK.dll";
+            public string PasswordSDKType => "CyberArk.AAM.NetStandardPasswordSDK.PasswordSDK";
+            public string PasswordRequestType => "CyberArk.AAM.NetStandardPasswordSDK.PSDKPasswordRequest";
+            public string PasswordSDKExceptionType => "CyberArk.AAM.NetStandardPasswordSDK.Exceptions.PSDKException";
+            public string PasswordResponseType => "CyberArk.AAM.NetStandardPasswordSDK.PSDKPassword";
+        }
+
+        public class NetFramework : SDK
+        {
+            public string DLL => "NetPasswordSDK.dll";
+            public string PasswordSDKType => "CyberArk.AIM.NetPasswordSDK.PasswordSDK";
+            public string PasswordRequestType => "CyberArk.AIM.NetPasswordSDK.PSDKPasswordRequest";
+            public string PasswordSDKExceptionType => "CyberArk.AIM.NetPasswordSDK.Exceptions.PSDKException";
+            public string PasswordResponseType => "CyberArk.AIM.NetPasswordSDK.PSDKPassword";
+        }
+    }
+}

--- a/cyberark-credentialprovider-pam/Constants.cs
+++ b/cyberark-credentialprovider-pam/Constants.cs
@@ -1,6 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright 2023 Keyfactor
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Keyfactor.Extensions.Pam.CyberArk
 {

--- a/cyberark-credentialprovider-pam/CyberArkProvider.cs
+++ b/cyberark-credentialprovider-pam/CyberArkProvider.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2023 Keyfactor
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Keyfactor.Extensions.Pam.CyberArk
+{
+    public class CyberArkProvider
+    {
+        protected string GetRequiredValue(Dictionary<string, string> dict, string key)
+        {
+            if (!dict.ContainsKey(key)
+                || string.IsNullOrWhiteSpace(dict[key]))
+            {
+                string error = $"Required field {key} was missing a value or was not defined as expected in dictionary.";
+                throw new ArgumentException(error);
+            }
+            return dict[key];
+        }
+    }
+}

--- a/cyberark-credentialprovider-pam/SdkCredentialProviderPAM.cs
+++ b/cyberark-credentialprovider-pam/SdkCredentialProviderPAM.cs
@@ -20,17 +20,17 @@ using System.Reflection;
 
 namespace Keyfactor.Extensions.Pam.CyberArk
 {
-    public class SdkCredentialProviderPAM : IPAMProvider
+    public class SdkCredentialProviderPAM : CyberArkProvider, IPAMProvider
     {
         public string Name => "CyberArk-SdkCredentialProvider";
 
         public string GetPassword(Dictionary<string, string> instanceParameters, Dictionary<string, string> initializationInfo)
         {
-            string appId = initializationInfo["AppId"];
+            string appId = GetRequiredValue(initializationInfo, "AppId");
 
-            string safe = instanceParameters["Safe"];
-            string folder = instanceParameters["Folder"];
-            string obj = instanceParameters["Object"];
+            string safe = GetRequiredValue(instanceParameters, "Safe");
+            string folder = GetRequiredValue(instanceParameters, "Folder");
+            string obj = GetRequiredValue(instanceParameters, "Object");
 
             string executingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string dll = Path.Combine(executingDir, "NetStandardPasswordSDK.dll");

--- a/cyberark-credentialprovider-pam/cyberark-credentialprovider-pam.csproj
+++ b/cyberark-credentialprovider-pam/cyberark-credentialprovider-pam.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,7 +8,16 @@
   <ItemGroup>
     <PackageReference Include="Keyfactor.Logging" Version="1.1.1" />
     <PackageReference Include="Keyfactor.Platform.IPAMProvider" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="SDK-manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/cyberark-credentialprovider-pam/cyberark-credentialprovider-pam.csproj
+++ b/cyberark-credentialprovider-pam/cyberark-credentialprovider-pam.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Keyfactor.Logging" Version="1.1.1" />
     <PackageReference Include="Keyfactor.Platform.IPAMProvider" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/cyberark-credentialprovider-pam/manifest.json
+++ b/cyberark-credentialprovider-pam/manifest.json
@@ -9,7 +9,7 @@
   },
   "Keyfactor:PAMProviders:CyberArk-CentralCredentialProvider:InitializationInfo": {
     "AppId": "myappid",
-    "Host": "https://my.cyberark.instance:99999",
+    "Host": "my.cyberark.instance:99999",
     "Site": "WithOutCert"
   }
 }

--- a/readme-src/readme-config.md
+++ b/readme-src/readme-config.md
@@ -6,6 +6,7 @@ Certificate Authentication cannot be required. This may necessitate creating a S
 
 #### For SDK-based local Credential Provider
 To use a local Credential Provider instead, the Credential Provider will need to be installed on the machine that is using the PAM Provider. After installing the Credential Provider, copy the `NetStandardPasswordSDK.dll` assembly from the install location into the PAM Provider install location. This dll __needs__ to be adjacent to `cyberark-credentialprovider-pam.dll` to be properly loaded.
+__Important__: When running the SDK Credential Provider on Keyfactor Command, the `NetPasswordSDK.dll` needs to be copied instead of `NetStandardPasswordSDK.dll`. This library is compatible with .NET Framework which is necessary to work in Keyfactor Command.
 
 After registering the Credential Provider during install, make sure the Provider for the machine has been granted permission to access the Safe, as well as the Application ID that will be used.
 

--- a/readme-src/readme-config.md
+++ b/readme-src/readme-config.md
@@ -19,7 +19,7 @@ A <code>manifest.json</code> file is included in the release. This file needs to
 ~~~ json
 "Keyfactor:PAMProviders:CyberArk-CentralCredentialProvider:InitializationInfo": {
     "AppId": "myappid",
-    "Host": "https://my.cyberark.instance:99999",
+    "Host": "my.cyberark.instance:99999",
     "Site": "WithOutCert"
   }
 ~~~

--- a/readme-src/readme-config.md
+++ b/readme-src/readme-config.md
@@ -43,10 +43,10 @@ This file then needs to be edited to enter in the "initialization" parameters fo
 
 #### Usage with the Keyfactor Universal Orchestrator
 To use the PAM Provider to resolve a field, for example a Server Password, instead of entering in the actual value for the Server Password, enter a `json` object with the parameters specifying the field.
-The parameters needed are the "instance" parameters above:
+The parameters needed are the "instance" parameters above (with appropriate characters escaped for correct JSON formatting):
 
 ~~~ json
-{"Safe":"MySafe","Folder":"Root\Secrets","Object":"MySecret"}
+{"Safe":"MySafe","Folder":"Root\\Secrets","Object":"MySecret"}
 ~~~
 
 If a field supports PAM but should not use PAM, simply enter in the actual value to be used instead of the `json` format object above.

--- a/readme-src/readme-register.md
+++ b/readme-src/readme-register.md
@@ -2,5 +2,11 @@
 For registering the CyberArk for use with the SDK-based Credential Provider, use the following `<register>` instead.
 
 ```xml
-<register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider" />
+<register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider">
+  <constructor>
+    <param name="extensionPath">
+      <value value="C:\Program Files\Keyfactor\Keyfactor Platform\WebAgentServices\bin"/>
+    </param>
+  </constructor>
+</register>
 ```

--- a/readme-src/readme-register.md
+++ b/readme-src/readme-register.md
@@ -1,5 +1,6 @@
 
 For registering the CyberArk for use with the SDK-based Credential Provider, use the following `<register>` instead.
+Make sure to enter in the correct full path to the directory for `extensionPath` that has the SDK DLL for the PAM Provider.
 
 ```xml
 <register type="IPAMProvider" mapTo="Keyfactor.Extensions.Pam.CyberArk.SdkCredentialProviderPAM, cyberark-credentialprovider-pam" name="CyberArk-SdkCredentialProvider">


### PR DESCRIPTION
In addition to allowing the path to be specified, there is also an optional flag to set whether the Framework (NetPasswordSDK) or Standard (NetStandardPasswordSDK) DLL should be used. By default the flag is not specified, and when using a Path the Framework version will be targeted (this is the scenario when using a Unity config).